### PR TITLE
build: Add python shebang to elf scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,14 +75,14 @@ target_link_libraries(${OUTPUT_NAME} PRIVATE c arith64 freertos_kernel pc xbox t
 
 # Create a binary from the elf
 add_custom_command(TARGET ${OUTPUT_NAME} POST_BUILD
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/calculate_usage.py ${CMAKE_BINARY_DIR}/${OUTPUT_NAME}
+    COMMAND ${CMAKE_CURRENT_LIST_DIR}/scripts/calculate_usage.py ${CMAKE_BINARY_DIR}/${OUTPUT_NAME}
 
     # Copy the original elf for debugging
     COMMAND cp ${CMAKE_BINARY_DIR}/${OUTPUT_NAME} ${CMAKE_BINARY_DIR}/original.elf
 
     COMMAND echo "Compressing ROM..."
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/compress_rom.py
-                                 ${CMAKE_BINARY_DIR}/${OUTPUT_NAME} ${CMAKE_BINARY_DIR}/compressed.bin
+    COMMAND ${CMAKE_CURRENT_LIST_DIR}/scripts/compress_rom.py
+            ${CMAKE_BINARY_DIR}/${OUTPUT_NAME} ${CMAKE_BINARY_DIR}/compressed.bin
 
     # Push the compressed blob back into the elf
     COMMAND ${CMAKE_OBJCOPY} --update-section .compressed=${CMAKE_BINARY_DIR}/compressed.bin ${OUTPUT_NAME}
@@ -91,7 +91,7 @@ add_custom_command(TARGET ${OUTPUT_NAME} POST_BUILD
     COMMAND ${CMAKE_OBJCOPY} --remove-section=.text --remove-section=.data --remove-section=.rodata ${OUTPUT_NAME}
 
     # Calculate the final size ROM usage
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/calculate_usage.py ${CMAKE_BINARY_DIR}/${OUTPUT_NAME}
+    COMMAND ${CMAKE_CURRENT_LIST_DIR}/scripts/calculate_usage.py ${CMAKE_BINARY_DIR}/${OUTPUT_NAME}
 
     # Convert the elf to a binary 0x100000000 is 256kB from ROM base which makes 256Kb output size
     COMMAND ${CMAKE_OBJCOPY} -O binary --pad-to 0x100000000 --gap-fill 0xFF ${OUTPUT_NAME} ${CMAKE_BINARY_DIR}/rom.bin

--- a/scripts/calculate_usage.py
+++ b/scripts/calculate_usage.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 from elftools.elf.elffile import ELFFile
 

--- a/scripts/compress_rom.py
+++ b/scripts/compress_rom.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from elftools.elf.elffile import ELFFile
 import lz4.block
 import struct


### PR DESCRIPTION
This pull request attempts to fix the following build failure on Gentoo Linux:
```
[100%] Building C object CMakeFiles/rom.elf.dir/lib/libfatx/fatx_log.c.obj
[100%] Building C object CMakeFiles/rom.elf.dir/lib/libfatx/fatx_misc.c.obj
[100%] Building C object CMakeFiles/rom.elf.dir/lib/libfatx/fatx_partition.c.obj
[100%] Building C object CMakeFiles/rom.elf.dir/lib/libfatx/ext.c.obj
[100%] Building C object CMakeFiles/rom.elf.dir/lib/lib9660/lib9660.c.obj
In file included from /home/amak79/Temp/XboxDoomBIOS/lib/lib9660/lib9660.c:19:
/home/amak79/Temp/XboxDoomBIOS/lib/lib9660/lib9660.h:111:5: warning: field '' with variable sized type 'union (anonymous at /home/amak79/Temp/XboxDoomBIOS/lib/lib9660/lib9660.h:111:5)' not at the end of a struct or class is a GNU extension [-Wgnu-variable-sized-type-not-at-end]
  111 |     union {
      |     ^
1 warning generated.
[100%] Building C object CMakeFiles/rom.elf.dir/lib/midi/midiplay.c.obj
[100%] Building C object CMakeFiles/rom.elf.dir/lib/midi/synth.c.obj
[100%] Linking C executable rom.elf
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: warning: portASM.S.obj: missing .note.GNU-stack section implies executable stack
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: warning: rom.elf has a LOAD segment with RWX permissions
Traceback (most recent call last):
  File "/home/amak79/Temp/XboxDoomBIOS/scripts/calculate_usage.py", line 2, in <module>
    from elftools.elf.elffile import ELFFile
ModuleNotFoundError: No module named 'elftools'
gmake[2]: *** [CMakeFiles/rom.elf.dir/build.make:970: rom.elf] Error 1
gmake[2]: *** Deleting file 'rom.elf'
gmake[1]: *** [CMakeFiles/Makefile2:1197: CMakeFiles/rom.elf.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```
I followed the build instructions except that I installed `pyelftools` with the Gentoo Linux package manager instead of `pip`.

I tracked it down to how Gentoo Linux handles Python. Multiple versions of Python can be installed, with one being set as active (currently 3.12). Most Python packages can also be built for multiple Python versions simultaneously.

The build fails because `pyelftools` is only built for Python 3.12, but my system also has Python 3.13 installed. CMake assumes Python 3.13 is the active version and sets `${Python_EXECUTABLE}` to `/usr/bin/python3.13`.

There is a way to tell the Gentoo Linux package manager to build `pyelftools` for every available Python version, but that requires the entire `pyelftools` dependency tree to be built for every available Python version. This becomes very messy and makes Python upgrades prone to failing.

My solution is to add a Python shebang to the elf scripts, which should always find the active Python version. This requires that the elf scripts are made executable (`scripts/calculate_usage.py` already is) and the removal `${Python_EXECUTABLE}` from `CMakeLists.txt`.

Please note that I'm a novice with Python and CMake so there could be some unforeseen issues. This change was only tested on Gentoo Linux.